### PR TITLE
Add news section to landingpage

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 webrick:
   headers:
     Access-Control-Allow-Origin: "*"
+permalink: /news/:year/:month/:day/:title.html

--- a/_includes/_landingpage/news.html
+++ b/_includes/_landingpage/news.html
@@ -1,0 +1,15 @@
+<h3>{{ include.title }}</h3>
+
+<ul>
+  {% for post in site.posts %}
+    {% capture slugsize %}{{ post.slug | split: '.' | size }}{% endcapture %}
+    {% capture lang %}{% if slugsize == '1' %}en{% else %}{{ post.slug | split: '.' | last }}{% endif %}{% endcapture %}
+    {% if include.lang ==  lang %}
+    <li>
+      <h4><a href="{{ post.url }}">{{ post.title }}</a></h4>
+      <small>{{ post.author }} on {{ post.date | date: "%m/%d/%Y" }}</small>
+      {{ post.excerpt }}
+    </li>
+    {% endif %}
+  {% endfor %}
+</ul>

--- a/_posts/2018-01-11-hello-world.de.md
+++ b/_posts/2018-01-11-hello-world.de.md
@@ -1,0 +1,9 @@
+---
+title: "Hallo, Welt!"
+layout: page
+author: <a href="/resource/urn:uuid:8082d2c7-8f40-449f-bd0b-581ce770ca27">Felix</a>
+---
+
+Hurra, nun gibt es auch Nachrichten! Der erste Absatz wird automatisch als Auszug verwendet.
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.

--- a/_posts/2018-01-11-hello-world.md
+++ b/_posts/2018-01-11-hello-world.md
@@ -1,0 +1,9 @@
+---
+title: "Hello, World!"
+layout: page
+author: <a href="/resource/urn:uuid:8082d2c7-8f40-449f-bd0b-581ce770ca27">Felix</a>
+---
+
+Yeah, we now have some news! The first paragraph will automatically be used as the excerpt.
+
+Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.

--- a/index.de.html
+++ b/index.de.html
@@ -34,6 +34,19 @@ layout: page
 </section>
 
 <section
+  id="news"
+  class="pageSection bg-white"
+>
+  <div class="inner">
+    {%
+      include _landingpage/news.html
+      lang="de"
+      title="Neues"
+    %}
+  </div>
+</section>
+
+<section
   id="adding-data"
   class="pageSection bg-light-grey bottom-0"
 >

--- a/index.html
+++ b/index.html
@@ -35,6 +35,19 @@ layout: page
 </section>
 
 <section
+  id="news"
+  class="pageSection bg-white"
+>
+  <div class="inner">
+    {%
+      include _landingpage/news.html
+      lang="en"
+      title="News"
+    %}
+  </div>
+</section>
+
+<section
   id="adding-data"
   class="pageSection bg-grey-lightest bottom-0 text-center"
 >


### PR DESCRIPTION
Basic news section, based on jekyll [`_posts`](https://jekyllrb.com/docs/posts/). The `news.html` include reads the post's date and language from the filename so that they don't have to be repeated in the front matter.